### PR TITLE
Textura aterciopelada suave en fondo negro

### DIFF
--- a/estructura.md
+++ b/estructura.md
@@ -72,7 +72,7 @@ Clases utilitarias globales: `.interactive-base` (transiciones), `.focus-ring` (
 
 **Anti-FOUC (flash blanco en prod):** Con `output: "server"`, el CSS externo puede llegar después del HTML. Mitigaciones en [`astro.config.mjs`](astro.config.mjs) y [`Layout.astro`](src/layouts/Layout.astro):
 - `build.inlineStylesheets: "always"` — inyecta Tailwind y estilos en `<style>` del `<head>` en el primer byte.
-- Fondo negro sólido (`#000`) inline en `<html>` — visible desde el primer paint en móvil; en `lg` (≥1024px) se añade cuadrícula vía CSS crítico inline y `global.css`.
+- Fondo negro (`#000`) con textura aterciopelada muy suave (ruido SVG + brillos radiales sutiles) inline en `<html>` y en `global.css`; en `lg` (≥1024px) se superpone la cuadrícula.
 - `Background.astro` con `hidden lg:block`, `z-0` y `transition:persist="site-background"` — gradiente radial solo en pantallas grandes; fondo estable en navegación SPA.
 - Imágenes/SVG con `view-transition-name: none` y `transition:animate="none"` en miniaturas de proyecto — evitan snapshots en View Transitions.
 - **Sin prerender** de rutas con i18n dinámico: el middleware resuelve idioma por cookie/`Accept-Language` en cada request.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,12 +27,45 @@ const pageBackground = "background-color:#000;color-scheme:dark";
         <meta name="viewport" content="width=device-width" />
         <meta name="color-scheme" content="dark" />
         <style is:inline>
+            html {
+                background-color: #000;
+                background-image:
+                    radial-gradient(
+                        ellipse 130% 85% at 12% -8%,
+                        rgba(255, 255, 255, 0.034),
+                        transparent 58%
+                    ),
+                    radial-gradient(
+                        ellipse 115% 75% at 100% 102%,
+                        rgba(255, 255, 255, 0.02),
+                        transparent 52%
+                    ),
+                    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/%3E%3C/svg%3E");
+                background-size: 100% 100%, 100% 100%, 200px 200px;
+            }
+
             @media (min-width: 1024px) {
                 html {
                     background-image:
                         linear-gradient(to right, #80808012 1px, transparent 1px),
-                        linear-gradient(to bottom, #80808012 1px, transparent 1px);
-                    background-size: 24px 24px;
+                        linear-gradient(to bottom, #80808012 1px, transparent 1px),
+                        radial-gradient(
+                            ellipse 130% 85% at 12% -8%,
+                            rgba(255, 255, 255, 0.034),
+                            transparent 58%
+                        ),
+                        radial-gradient(
+                            ellipse 115% 75% at 100% 102%,
+                            rgba(255, 255, 255, 0.02),
+                            transparent 52%
+                        ),
+                        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/%3E%3C/svg%3E");
+                    background-size:
+                        24px 24px,
+                        24px 24px,
+                        100% 100%,
+                        100% 100%,
+                        200px 200px;
                 }
             }
         </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,9 +11,13 @@
     --duration-fast: 150ms;
     --duration-base: 250ms;
     --duration-slow: 400ms;
+
+    --bg-velvet-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/%3E%3C/svg%3E");
+    --bg-velvet-sheen:
+        radial-gradient(ellipse 130% 85% at 12% -8%, rgba(255, 255, 255, 0.034), transparent 58%),
+        radial-gradient(ellipse 115% 75% at 100% 102%, rgba(255, 255, 255, 0.02), transparent 52%);
 }
 
-/* Reserva espacio para la barra y evita saltos al cambiar de modo / altura de página */
 html {
     scrollbar-gutter: stable;
     scrollbar-width: thin;
@@ -21,6 +25,8 @@ html {
         transparent;
     overflow-x: clip;
     background-color: #000;
+    background-image: var(--bg-velvet-sheen), var(--bg-velvet-noise);
+    background-size: 100% 100%, 200px 200px;
     color-scheme: dark;
 }
 
@@ -28,8 +34,14 @@ html {
     html {
         background-image:
             linear-gradient(to right, #80808012 1px, transparent 1px),
-            linear-gradient(to bottom, #80808012 1px, transparent 1px);
-        background-size: 24px 24px;
+            linear-gradient(to bottom, #80808012 1px, transparent 1px),
+            var(--bg-velvet-sheen),
+            var(--bg-velvet-noise);
+        background-size:
+            24px 24px,
+            24px 24px,
+            100% 100%,
+            200px 200px;
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Añade una textura muy sutil tipo aterciopelado al fondo negro del portfolio.

## Cambios

- Capa de ruido SVG fino (`feTurbulence`) con opacidad baja
- Dos brillos radiales suaves para dar profundidad mate
- En desktop (`lg+`) la cuadrícula existente se mantiene como capa superior
- CSS crítico inline en `Layout.astro` para evitar FOUC

## Verificación

- `npm run build` ✓
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e20f3395-7373-40a3-8d9f-4536743c62b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e20f3395-7373-40a3-8d9f-4536743c62b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

